### PR TITLE
Feature beregn bps andel av underholdskostnad

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Repo for beregning av barnebidrag-core. Disse erstatter beregninger i BBM.
 
 Versjon | Endringstype | Beskrivelse
 --------|--------------|------------
+0.3.4   | Endret       | Beregn-til-dato legges nå med i perioder som skal beregnes for å sikre minst én resultatperiode der det er ingen bruddpunkter i andre parametre
 0.3.3   | Endret       | Logikk lagt til for å håndtere to sett med regler
 0.3.2   | Endret       | Slått av test på overlapp og opphold i faktisk utgift-perioder pga flere barn i input
 0.3.1   | Endret       | Lagt til test på summering av faktiske utgifter per barn

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Repo for beregning av barnebidrag-core. Disse erstatter beregninger i BBM.
 
 Versjon | Endringstype | Beskrivelse
 --------|--------------|------------
+0.3.3   | Endret       | Logikk lagt til for å håndtere to sett med regler
 0.3.2   | Endret       | Slått av test på overlapp og opphold i faktisk utgift-perioder pga flere barn i input
 0.3.1   | Endret       | Lagt til test på summering av faktiske utgifter per barn
 0.3.0   | Endret       | Forenklet DTO for netto barnetilsyn og åpnet for set-metoder på noen av input-variablene

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCore.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCore.java
@@ -1,0 +1,16 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadGrunnlagCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadResultatCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode.BPsAndelUnderholdskostnadPeriode;
+
+public interface BPsAndelUnderholdskostnadCore {
+
+  BeregnBPsAndelUnderholdskostnadResultatCore beregnBPsAndelUnderholdskostnad (
+      BeregnBPsAndelUnderholdskostnadGrunnlagCore beregnBPsAndelUnderholdskostnadGrunnlagCore);
+
+  static BPsAndelUnderholdskostnadCore getInstance() {
+    return new BPsAndelUnderholdskostnadCoreImpl(BPsAndelUnderholdskostnadPeriode.getInstance());
+  }
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCoreImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCoreImpl.java
@@ -1,0 +1,144 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlag;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadResultat;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.InntekterPeriode;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatPeriode;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadGrunnlagCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadResultatCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.InntekterPeriodeCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatBeregningCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatGrunnlagCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.ResultatPeriodeCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode.BPsAndelUnderholdskostnadPeriode;
+import no.nav.bidrag.beregn.felles.bo.Avvik;
+import no.nav.bidrag.beregn.felles.bo.Periode;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+import no.nav.bidrag.beregn.felles.bo.SjablonInnhold;
+import no.nav.bidrag.beregn.felles.bo.SjablonNokkel;
+import no.nav.bidrag.beregn.felles.bo.SjablonPeriode;
+import no.nav.bidrag.beregn.felles.dto.AvvikCore;
+import no.nav.bidrag.beregn.felles.dto.PeriodeCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonInnholdCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonNokkelCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonPeriodeCore;
+
+public class BPsAndelUnderholdskostnadCoreImpl implements BPsAndelUnderholdskostnadCore{
+
+  public BPsAndelUnderholdskostnadCoreImpl(
+      BPsAndelUnderholdskostnadPeriode bPsAndelunderholdskostnadPeriode) {
+    this.bPsAndelunderholdskostnadPeriode = bPsAndelunderholdskostnadPeriode;
+  }
+
+  private BPsAndelUnderholdskostnadPeriode bPsAndelunderholdskostnadPeriode;
+
+
+  @Override
+  public BeregnBPsAndelUnderholdskostnadResultatCore beregnBPsAndelUnderholdskostnad(
+      BeregnBPsAndelUnderholdskostnadGrunnlagCore beregnBPsAndelUnderholdskostnadGrunnlagCore) {
+
+
+    var beregnBPsAndelUnderholdskostnadGrunnlag = mapTilBusinessObject(beregnBPsAndelUnderholdskostnadGrunnlagCore);
+    var beregnBPsAndelUnderholdskostnadResultat = new BeregnBPsAndelUnderholdskostnadResultat(Collections.emptyList());
+    var avvikListe = bPsAndelunderholdskostnadPeriode.validerInput(beregnBPsAndelUnderholdskostnadGrunnlag);
+    if (avvikListe.isEmpty()) {
+      beregnBPsAndelUnderholdskostnadResultat = bPsAndelunderholdskostnadPeriode.beregnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag);
+    }
+    return mapFraBusinessObject(avvikListe, beregnBPsAndelUnderholdskostnadResultat);
+  }
+
+  private BeregnBPsAndelUnderholdskostnadGrunnlag mapTilBusinessObject(
+      BeregnBPsAndelUnderholdskostnadGrunnlagCore beregnBPsAndelUnderholdskostnadGrunnlagCore) {
+    var beregnDatoFra = beregnBPsAndelUnderholdskostnadGrunnlagCore.getBeregnDatoFra();
+    var beregnDatoTil = beregnBPsAndelUnderholdskostnadGrunnlagCore.getBeregnDatoTil();
+    var sjablonPeriodeListe = mapSjablonPeriodeListe(beregnBPsAndelUnderholdskostnadGrunnlagCore.getSjablonPeriodeListe());
+    var inntekterPeriodeListe = mapInntekterPeriodeListe(beregnBPsAndelUnderholdskostnadGrunnlagCore.getInntekterPeriodeListe());
+
+    return new BeregnBPsAndelUnderholdskostnadGrunnlag(beregnDatoFra, beregnDatoTil, inntekterPeriodeListe, sjablonPeriodeListe);
+  }
+
+  private List<SjablonPeriode> mapSjablonPeriodeListe(List<SjablonPeriodeCore> sjablonPeriodeListeCore) {
+    var sjablonPeriodeListe = new ArrayList<SjablonPeriode>();
+    for (SjablonPeriodeCore sjablonPeriodeCore : sjablonPeriodeListeCore) {
+      var sjablonNokkelListe = new ArrayList<SjablonNokkel>();
+      var sjablonInnholdListe = new ArrayList<SjablonInnhold>();
+      for (SjablonNokkelCore sjablonNokkelCore : sjablonPeriodeCore.getSjablonNokkelListe()) {
+        sjablonNokkelListe.add(new SjablonNokkel(sjablonNokkelCore.getSjablonNokkelNavn(), sjablonNokkelCore.getSjablonNokkelVerdi()));
+      }
+      for (SjablonInnholdCore sjablonInnholdCore : sjablonPeriodeCore.getSjablonInnholdListe()) {
+        sjablonInnholdListe.add(new SjablonInnhold(sjablonInnholdCore.getSjablonInnholdNavn(), sjablonInnholdCore.getSjablonInnholdVerdi()));
+      }
+      sjablonPeriodeListe.add(new SjablonPeriode(
+          new Periode(sjablonPeriodeCore.getSjablonPeriodeDatoFraTil().getPeriodeDatoFra(),
+              sjablonPeriodeCore.getSjablonPeriodeDatoFraTil().getPeriodeDatoTil()),
+          new Sjablon(sjablonPeriodeCore.getSjablonNavn(), sjablonNokkelListe, sjablonInnholdListe)));
+    }
+    return sjablonPeriodeListe;
+  }
+
+  private List<InntekterPeriode> mapInntekterPeriodeListe(List<InntekterPeriodeCore> inntekterPeriodeListeCore) {
+    var inntekterPeriodeListe = new ArrayList<InntekterPeriode>();
+    for (InntekterPeriodeCore inntekterPeriodeCore : inntekterPeriodeListeCore) {
+      inntekterPeriodeListe.add(new InntekterPeriode(
+          new Periode(inntekterPeriodeCore.getInntekterPeriodeDatoFraTil().getPeriodeDatoFra(),
+              inntekterPeriodeCore.getInntekterPeriodeDatoFraTil().getPeriodeDatoTil()),
+          inntekterPeriodeCore.getInntektBP(),
+          inntekterPeriodeCore.getInntektBM(),
+          inntekterPeriodeCore.getInntektBB()));
+    }
+    return inntekterPeriodeListe;
+  }
+
+
+
+  private BeregnBPsAndelUnderholdskostnadResultatCore mapFraBusinessObject(List<Avvik> avvikListe, BeregnBPsAndelUnderholdskostnadResultat resultat) {
+    return new BeregnBPsAndelUnderholdskostnadResultatCore(mapResultatPeriode(resultat.getResultatPeriodeListe()), mapAvvik(avvikListe));
+  }
+
+  private List<AvvikCore> mapAvvik(List<Avvik> avvikListe) {
+    var avvikCoreListe = new ArrayList<AvvikCore>();
+    for (Avvik avvik : avvikListe) {
+      avvikCoreListe.add(new AvvikCore(avvik.getAvvikTekst(), avvik.getAvvikType().toString()));
+    }
+    return avvikCoreListe;
+  }
+
+  private List<ResultatPeriodeCore> mapResultatPeriode(List<ResultatPeriode> periodeResultatListe) {
+    var resultatPeriodeCoreListe = new ArrayList<ResultatPeriodeCore>();
+    for (ResultatPeriode periodeResultat : periodeResultatListe) {
+      var bPsAndelunderholdskostnadResultat = periodeResultat.getResultatBeregning();
+      var bPsAndelunderholdskostnadResultatGrunnlag = periodeResultat.getResultatGrunnlag();
+      resultatPeriodeCoreListe.add(new ResultatPeriodeCore(
+          new PeriodeCore(periodeResultat.getResultatDatoFraTil().getDatoFra(), periodeResultat.getResultatDatoFraTil().getDatoTil()),
+          new ResultatBeregningCore(bPsAndelunderholdskostnadResultat.getResultatAndelProsent()),
+          new ResultatGrunnlagCore(bPsAndelunderholdskostnadResultatGrunnlag.getInntekter().getInntektBP(),
+              bPsAndelunderholdskostnadResultatGrunnlag.getInntekter().getInntektBM(),
+              bPsAndelunderholdskostnadResultatGrunnlag.getInntekter().getInntektBB(),
+              mapResultatGrunnlagSjabloner(bPsAndelunderholdskostnadResultatGrunnlag.getSjablonListe()))));
+    }
+    return resultatPeriodeCoreListe;
+  }
+
+  private List<SjablonCore> mapResultatGrunnlagSjabloner(List<Sjablon> resultatGrunnlagSjablonListe) {
+    var resultatGrunnlagSjablonListeCore = new ArrayList<SjablonCore>();
+    for (Sjablon resultatGrunnlagSjablon : resultatGrunnlagSjablonListe) {
+      var sjablonNokkelListeCore = new ArrayList<SjablonNokkelCore>();
+      var sjablonInnholdListeCore = new ArrayList<SjablonInnholdCore>();
+      for (SjablonNokkel sjablonNokkel : resultatGrunnlagSjablon.getSjablonNokkelListe()) {
+        sjablonNokkelListeCore.add(new SjablonNokkelCore(sjablonNokkel.getSjablonNokkelNavn(), sjablonNokkel.getSjablonNokkelVerdi()));
+      }
+      for (SjablonInnhold sjablonInnhold : resultatGrunnlagSjablon.getSjablonInnholdListe()) {
+        sjablonInnholdListeCore.add(new SjablonInnholdCore(sjablonInnhold.getSjablonInnholdNavn(), sjablonInnhold.getSjablonInnholdVerdi()));
+      }
+      resultatGrunnlagSjablonListeCore
+          .add(new SjablonCore(resultatGrunnlagSjablon.getSjablonNavn(), sjablonNokkelListeCore, sjablonInnholdListeCore));
+    }
+
+    return resultatGrunnlagSjablonListeCore;
+  }
+
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregning.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregning.java
@@ -8,6 +8,8 @@ public interface BPsAndelUnderholdskostnadBeregning {
   ResultatBeregning beregn(
       BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
 
+  ResultatBeregning beregnMedGamleRegler(
+      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
 
   static BPsAndelUnderholdskostnadBeregning getInstance(){
     return new BPsAndelUnderholdskostnadBeregningImpl();

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregning.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregning.java
@@ -1,0 +1,16 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning;
+
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatBeregning;
+
+public interface BPsAndelUnderholdskostnadBeregning {
+
+  ResultatBeregning beregn(
+      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+
+  static BPsAndelUnderholdskostnadBeregning getInstance(){
+    return new BPsAndelUnderholdskostnadBeregningImpl();
+  }
+
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregningImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregningImpl.java
@@ -1,0 +1,28 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning;
+
+import java.util.ArrayList;
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatBeregning;
+import no.nav.bidrag.beregn.felles.bo.SjablonNokkel;
+
+public class BPsAndelUnderholdskostnadBeregningImpl implements BPsAndelUnderholdskostnadBeregning {
+
+  private List<SjablonNokkel> sjablonNokkelListe = new ArrayList<>();
+
+  @Override
+  public ResultatBeregning beregn(
+      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert){
+
+    Double andel = beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() /
+        (beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() +
+         beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBM() +
+         beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB());
+
+    andel = Math.round(andel * 1000.0) / 1000.0;
+
+    return new ResultatBeregning(andel);
+
+  }
+
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregningImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/beregning/BPsAndelUnderholdskostnadBeregningImpl.java
@@ -1,10 +1,15 @@
 package no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
 import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatBeregning;
+import no.nav.bidrag.beregn.felles.SjablonUtil;
 import no.nav.bidrag.beregn.felles.bo.SjablonNokkel;
+import no.nav.bidrag.beregn.felles.enums.SjablonTallNavn;
 
 public class BPsAndelUnderholdskostnadBeregningImpl implements BPsAndelUnderholdskostnadBeregning {
 
@@ -12,17 +17,87 @@ public class BPsAndelUnderholdskostnadBeregningImpl implements BPsAndelUnderhold
 
   @Override
   public ResultatBeregning beregn(
-      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert){
+      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert) {
 
-    Double andel = beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() /
-        (beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() +
-         beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBM() +
-         beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB());
+    BigDecimal andel;
 
-    andel = Math.round(andel * 1000.0) / 1000.0;
+    // Test på om barnets inntekt er høyere enn 100 ganger sats for forhøyet forskudd. Hvis så så skal ikke BPs andel regnes ut.
+    if ((beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB()
+        > SjablonUtil
+        .hentSjablonverdi(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getSjablonListe(),
+            SjablonTallNavn.FORSKUDDSSATS_BELOP) * 100)) {
+      andel = BigDecimal.valueOf(0.0);
+    } else {
+      andel = BigDecimal.valueOf(
+          beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() /
+              (beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() +
+                  beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBM() +
+                  beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB()))
+          .multiply(BigDecimal.valueOf(100));
 
-    return new ResultatBeregning(andel);
+      andel = andel.setScale(1, RoundingMode.HALF_UP);
+
+      // Utregnet andel skal ikke være større en 5/6
+
+      if (andel.compareTo(BigDecimal.valueOf(83.3)) > 0) {
+        andel = BigDecimal.valueOf(83.3);
+      }
+
+    }
+
+    return new ResultatBeregning(andel.doubleValue());
 
   }
 
+  @Override
+  public ResultatBeregning beregnMedGamleRegler(
+      BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert) {
+
+    BigDecimal andel;
+
+    // Test på om barnets inntekt er høyere enn 100 ganger sats for forhøyet forskudd. Hvis så så skal ikke BPs andel regnes ut.
+    if ((beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB()
+        > SjablonUtil
+        .hentSjablonverdi(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getSjablonListe(),
+            SjablonTallNavn.FORSKUDDSSATS_BELOP) * 100)) {
+      andel = BigDecimal.valueOf(0.0);
+    } else {
+      andel = BigDecimal.valueOf(
+          beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() /
+              (beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBP() +
+                  beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBM() +
+                  beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert.getInntekter().getInntektBB()))
+          .multiply(BigDecimal.valueOf(100));
+
+      var sjettedeler = new ArrayList<BigDecimal>();
+
+      sjettedeler.add(BigDecimal.valueOf((1.0 / 6)).multiply(BigDecimal.valueOf(100)));
+      sjettedeler.add(BigDecimal.valueOf((2.0 / 6)).multiply(BigDecimal.valueOf(100)));
+      sjettedeler.add(BigDecimal.valueOf((3.0 / 6)).multiply(BigDecimal.valueOf(100)));
+      sjettedeler.add(BigDecimal.valueOf((4.0 / 6)).multiply(BigDecimal.valueOf(100)));
+      sjettedeler.add(BigDecimal.valueOf((5.0 / 6)).multiply(BigDecimal.valueOf(100)));
+
+//      BigDecimal finalAndel = andel;
+      BigDecimal finalAndel = andel;
+      andel = sjettedeler.stream()
+          .min(Comparator.comparing(a -> finalAndel.subtract(a).abs()))
+          .orElseThrow(() -> new IllegalArgumentException("Empty collection"));
+
+
+      andel = andel.setScale(1, RoundingMode.HALF_UP);
+
+      // Utregnet andel skal ikke være større en 5/6
+
+      if (andel.compareTo(BigDecimal.valueOf(83.3)) > 0) {
+        andel = BigDecimal.valueOf(83.3);
+      }
+    }
+
+    return new ResultatBeregning(andel.doubleValue());
+
+    }
+
 }
+
+
+

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriode.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriode.java
@@ -1,0 +1,19 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode;
+
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning.BPsAndelUnderholdskostnadBeregning;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlag;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadResultat;
+import no.nav.bidrag.beregn.felles.bo.Avvik;
+
+public interface BPsAndelUnderholdskostnadPeriode {
+  BeregnBPsAndelUnderholdskostnadResultat beregnPerioder(
+      BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag);
+
+  List<Avvik> validerInput(BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag);
+
+  static BPsAndelUnderholdskostnadPeriode getInstance() {
+    return new BPsAndelUnderholdskostnadPeriodeImpl(BPsAndelUnderholdskostnadBeregning.getInstance());
+  }
+
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
@@ -1,0 +1,186 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode;
+
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Collectors.toList;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning.BPsAndelUnderholdskostnadBeregning;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlag;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadResultat;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.Inntekter;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.InntekterPeriode;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatPeriode;
+import no.nav.bidrag.beregn.felles.bo.Avvik;
+import no.nav.bidrag.beregn.felles.bo.Periode;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+import no.nav.bidrag.beregn.felles.bo.SjablonPeriode;
+import no.nav.bidrag.beregn.felles.enums.AvvikType;
+import no.nav.bidrag.beregn.felles.periode.Periodiserer;
+
+public class BPsAndelUnderholdskostnadPeriodeImpl implements BPsAndelUnderholdskostnadPeriode{
+  public BPsAndelUnderholdskostnadPeriodeImpl(
+      BPsAndelUnderholdskostnadBeregning bPsAndelUnderholdskostnadBeregning) {
+    this.bPsAndelUnderholdskostnadBeregning = bPsAndelUnderholdskostnadBeregning;
+  }
+
+  private BPsAndelUnderholdskostnadBeregning bPsAndelUnderholdskostnadBeregning;
+
+  public BeregnBPsAndelUnderholdskostnadResultat beregnPerioder(
+      BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag) {
+
+    var resultatPeriodeListe = new ArrayList<ResultatPeriode>();
+
+    var justertInntekterPeriodeListe = beregnBPsAndelUnderholdskostnadGrunnlag.getInntekterPeriodeListe()
+        .stream()
+        .map(InntekterPeriode::new)
+        .collect(toCollection(ArrayList::new));
+
+    var justertSjablonPeriodeListe = beregnBPsAndelUnderholdskostnadGrunnlag.getSjablonPeriodeListe()
+        .stream()
+        .map(SjablonPeriode::new)
+        .collect(toCollection(ArrayList::new));
+
+    // Bygger opp liste over perioder
+    List<Periode> perioder = new Periodiserer()
+        .addBruddpunkt(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra()) //For å sikre bruddpunkt på start-beregning-fra-dato
+        .addBruddpunkter(justertInntekterPeriodeListe)
+        .finnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra(), beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil());
+
+    // Hvis det ligger 2 perioder på slutten som i til-dato inneholder hhv. beregningsperiodens til-dato og null slås de sammen
+    if (perioder.size() > 1) {
+      if ((perioder.get(perioder.size() - 2).getDatoTil().equals(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil())) &&
+          (perioder.get(perioder.size() - 1).getDatoTil() == null)) {
+        var nyPeriode = new Periode(perioder.get(perioder.size() - 2).getDatoFra(), null);
+        perioder.remove(perioder.size() - 1);
+        perioder.remove(perioder.size() - 1);
+        perioder.add(nyPeriode);
+      }
+    }
+
+    // Løper gjennom periodene og finner matchende verdi for hver kategori. Kaller beregningsmodulen for hver beregningsperiode
+    for (Periode beregningsperiode : perioder) {
+
+      var inntekter = justertInntekterPeriodeListe.stream().filter(i -> i.getDatoFraTil().overlapperMed(beregningsperiode))
+          .map(inntekterPeriode -> new Inntekter(inntekterPeriode.getInntektBP(), inntekterPeriode.getInntektBM(),
+              inntekterPeriode.getInntektBB())).findFirst().orElse(null);
+
+      var sjablonliste = justertSjablonPeriodeListe.stream().filter(i -> i.getDatoFraTil().overlapperMed(beregningsperiode))
+          .map(sjablonPeriode -> new Sjablon(sjablonPeriode.getSjablon().getSjablonNavn(),
+              sjablonPeriode.getSjablon().getSjablonNokkelListe(),
+              sjablonPeriode.getSjablon().getSjablonInnholdListe())).collect(toList());
+
+      // Kaller beregningsmodulen for hver beregningsperiode
+      var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert = new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(
+          inntekter, sjablonliste);
+
+      resultatPeriodeListe.add(new ResultatPeriode(beregningsperiode,
+          bPsAndelUnderholdskostnadBeregning.beregn(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert),
+          beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert));
+    }
+
+    //Slår sammen perioder med samme resultat
+    return new BeregnBPsAndelUnderholdskostnadResultat(resultatPeriodeListe);
+
+
+  }
+
+
+  // Validerer at input-verdier til underholdskostnadsberegning er gyldige
+  public List<Avvik> validerInput(BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag) {
+    var avvikListe = new ArrayList<Avvik>();
+
+    // Sjekk perioder for sjablonliste
+    var sjablonPeriodeListe = new ArrayList<Periode>();
+    for (SjablonPeriode sjablonPeriode : beregnBPsAndelUnderholdskostnadGrunnlag.getSjablonPeriodeListe()) {
+      sjablonPeriodeListe.add(sjablonPeriode.getDatoFraTil());
+    }
+    avvikListe.addAll(validerInput("sjablonPeriodeListe", sjablonPeriodeListe, false, false, false));
+
+    // Sjekk perioder for barnetilsynMedStonad
+    var inntekterPeriodeListe = new ArrayList<Periode>();
+    for (InntekterPeriode inntekterPeriode : beregnBPsAndelUnderholdskostnadGrunnlag.getInntekterPeriodeListe()) {
+      inntekterPeriodeListe.add(inntekterPeriode.getDatoFraTil());
+    }
+    avvikListe.addAll(validerInput("inntekterListe", inntekterPeriodeListe, true, true, true));
+
+
+    // Sjekk beregn dato fra/til
+    avvikListe.addAll(validerBeregnPeriodeInput(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra(), beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil()));
+
+    return avvikListe;
+  }
+
+  // Validerer at datoer er gyldige
+  private List<Avvik> validerInput(String dataElement, List<Periode> periodeListe, boolean sjekkOverlapp, boolean sjekkOpphold, boolean sjekkNull) {
+    var avvikListe = new ArrayList<Avvik>();
+    int indeks = 0;
+    Periode forrigePeriode = null;
+
+    for (Periode dennePeriode : periodeListe) {
+      indeks++;
+
+      //Sjekk om perioder overlapper
+      if (sjekkOverlapp) {
+        if (dennePeriode.overlapper(forrigePeriode)) {
+          var feilmelding = "Overlappende perioder i " + dataElement + ": periodeDatoTil=" + forrigePeriode.getDatoTil() + ", periodeDatoFra=" +
+              dennePeriode.getDatoFra();
+          avvikListe.add(new Avvik(feilmelding, AvvikType.PERIODER_OVERLAPPER));
+        }
+      }
+
+      //Sjekk om det er opphold mellom perioder
+      if (sjekkOpphold) {
+        if (dennePeriode.harOpphold(forrigePeriode)) {
+          var feilmelding = "Opphold mellom perioder i " + dataElement + ": periodeDatoTil=" + forrigePeriode.getDatoTil() + ", periodeDatoFra=" +
+              dennePeriode.getDatoFra();
+          avvikListe.add(new Avvik(feilmelding, AvvikType.PERIODER_HAR_OPPHOLD));
+        }
+      }
+
+      //Sjekk om dato er null
+      if (sjekkNull) {
+        if ((indeks != periodeListe.size()) && (dennePeriode.getDatoTil() == null)) {
+          var feilmelding = "periodeDatoTil kan ikke være null i " + dataElement + ": periodeDatoFra=" + dennePeriode.getDatoFra() +
+              ", periodeDatoTil=" + dennePeriode.getDatoTil();
+          avvikListe.add(new Avvik(feilmelding, AvvikType.NULL_VERDI_I_DATO));
+        }
+        if ((indeks != 1) && (dennePeriode.getDatoFra() == null)) {
+          var feilmelding = "periodeDatoFra kan ikke være null i " + dataElement + ": periodeDatoFra=" + dennePeriode.getDatoFra() +
+              ", periodeDatoTil=" + dennePeriode.getDatoTil();
+          avvikListe.add(new Avvik(feilmelding, AvvikType.NULL_VERDI_I_DATO));
+        }
+      }
+
+      //Sjekk om dato fra er etter dato til
+      if (!(dennePeriode.datoTilErEtterDatoFra())) {
+        var feilmelding = "periodeDatoTil må være etter periodeDatoFra i " + dataElement + ": periodeDatoFra=" + dennePeriode.getDatoFra() +
+            ", periodeDatoTil=" + dennePeriode.getDatoTil();
+        avvikListe.add(new Avvik(feilmelding, AvvikType.DATO_FRA_ETTER_DATO_TIL));
+      }
+
+      forrigePeriode = new Periode(dennePeriode.getDatoFra(), dennePeriode.getDatoTil());
+    }
+
+    return avvikListe;
+  }
+
+  // Validerer at beregningsperiode fra/til er gyldig
+  private List<Avvik> validerBeregnPeriodeInput(LocalDate beregnDatoFra, LocalDate beregnDatoTil) {
+    var avvikListe = new ArrayList<Avvik>();
+
+    if (beregnDatoFra == null) {
+      avvikListe.add(new Avvik("beregnDatoFra kan ikke være null", AvvikType.NULL_VERDI_I_DATO));
+    }
+    if (beregnDatoTil == null) {
+      avvikListe.add(new Avvik("beregnDatoTil kan ikke være null", AvvikType.NULL_VERDI_I_DATO));
+    }
+    if (!new Periode(beregnDatoFra, beregnDatoTil).datoTilErEtterDatoFra()) {
+      avvikListe.add(new Avvik("beregnDatoTil må være etter beregnDatoFra", AvvikType.DATO_FRA_ETTER_DATO_TIL));
+    }
+
+    return avvikListe;
+  }
+}

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
@@ -45,6 +45,9 @@ public class BPsAndelUnderholdskostnadPeriodeImpl implements BPsAndelUnderholdsk
 
     // Bygger opp liste over perioder
     List<Periode> perioder = new Periodiserer()
+
+      //  Her må det lages brudd for regelendringer !
+
         .addBruddpunkt(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra()) //For å sikre bruddpunkt på start-beregning-fra-dato
         .addBruddpunkter(justertInntekterPeriodeListe)
         .finnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra(), beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil());

--- a/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/periode/BPsAndelUnderholdskostnadPeriodeImpl.java
@@ -54,6 +54,7 @@ public class BPsAndelUnderholdskostnadPeriodeImpl implements BPsAndelUnderholdsk
         .addBruddpunkter(justertSjablonPeriodeListe)
         .addBruddpunkter(datoRegelendringer)
         .addBruddpunkter(justertInntekterPeriodeListe)
+        .addBruddpunkt(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil()) //For å sikre bruddpunkt på start-beregning-til-dato
         .finnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoFra(), beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil());
 
     // Hvis det ligger 2 perioder på slutten som i til-dato inneholder hhv. beregningsperiodens til-dato og null slås de sammen

--- a/src/main/java/no/nav/bidrag/beregn/underholdskostnad/beregning/UnderholdskostnadBeregning.java
+++ b/src/main/java/no/nav/bidrag/beregn/underholdskostnad/beregning/UnderholdskostnadBeregning.java
@@ -3,7 +3,7 @@ package no.nav.bidrag.beregn.underholdskostnad.beregning;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadGrunnlagPeriodisert;
 import no.nav.bidrag.beregn.underholdskostnad.bo.ResultatBeregning;
 
-public interface Underholdskostnadberegning {
+public interface UnderholdskostnadBeregning {
 
   ResultatBeregning beregn(
       BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert);
@@ -11,8 +11,8 @@ public interface Underholdskostnadberegning {
   Double beregnBarnetilsynMedStonad(
       BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert);
 
-  static Underholdskostnadberegning getInstance(){
-    return new UnderholdskostnadberegningImpl();
+  static UnderholdskostnadBeregning getInstance(){
+    return new UnderholdskostnadBeregningImpl();
   }
 
 }

--- a/src/main/java/no/nav/bidrag/beregn/underholdskostnad/beregning/UnderholdskostnadBeregningImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/underholdskostnad/beregning/UnderholdskostnadBeregningImpl.java
@@ -11,7 +11,7 @@ import no.nav.bidrag.beregn.felles.enums.SjablonTallNavn;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadGrunnlagPeriodisert;
 import no.nav.bidrag.beregn.underholdskostnad.bo.ResultatBeregning;
 
-public class UnderholdskostnadberegningImpl implements Underholdskostnadberegning {
+public class UnderholdskostnadBeregningImpl implements UnderholdskostnadBeregning {
 
   private List<SjablonNokkel> sjablonNokkelListe = new ArrayList<>();
 

--- a/src/main/java/no/nav/bidrag/beregn/underholdskostnad/periode/UnderholdskostnadPeriode.java
+++ b/src/main/java/no/nav/bidrag/beregn/underholdskostnad/periode/UnderholdskostnadPeriode.java
@@ -3,7 +3,7 @@ package no.nav.bidrag.beregn.underholdskostnad.periode;
 import java.time.LocalDate;
 import java.util.List;
 import no.nav.bidrag.beregn.felles.bo.Avvik;
-import no.nav.bidrag.beregn.underholdskostnad.beregning.Underholdskostnadberegning;
+import no.nav.bidrag.beregn.underholdskostnad.beregning.UnderholdskostnadBeregning;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadGrunnlag;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadResultat;
 
@@ -14,7 +14,7 @@ public interface UnderholdskostnadPeriode {
   List<Avvik> validerInput(BeregnUnderholdskostnadGrunnlag beregnUnderholdskostnadGrunnlag);
 
   static UnderholdskostnadPeriode getInstance() {
-    return new UnderholdskostnadPeriodeImpl(Underholdskostnadberegning.getInstance());
+    return new UnderholdskostnadPeriodeImpl(UnderholdskostnadBeregning.getInstance());
   }
 
   Integer beregnSoknadbarnAlder(

--- a/src/main/java/no/nav/bidrag/beregn/underholdskostnad/periode/UnderholdskostnadPeriodeImpl.java
+++ b/src/main/java/no/nav/bidrag/beregn/underholdskostnad/periode/UnderholdskostnadPeriodeImpl.java
@@ -13,7 +13,7 @@ import no.nav.bidrag.beregn.felles.bo.Sjablon;
 import no.nav.bidrag.beregn.felles.bo.SjablonPeriode;
 import no.nav.bidrag.beregn.felles.enums.AvvikType;
 import no.nav.bidrag.beregn.felles.periode.Periodiserer;
-import no.nav.bidrag.beregn.underholdskostnad.beregning.Underholdskostnadberegning;
+import no.nav.bidrag.beregn.underholdskostnad.beregning.UnderholdskostnadBeregning;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BarnetilsynMedStonad;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BarnetilsynMedStonadPeriode;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadGrunnlag;
@@ -25,11 +25,11 @@ import no.nav.bidrag.beregn.underholdskostnad.bo.ResultatPeriode;
 
 public class UnderholdskostnadPeriodeImpl implements UnderholdskostnadPeriode{
 
-  public UnderholdskostnadPeriodeImpl(Underholdskostnadberegning underholdskostnadberegning) {
+  public UnderholdskostnadPeriodeImpl(UnderholdskostnadBeregning underholdskostnadberegning) {
     this.underholdskostnadberegning = underholdskostnadberegning;
   }
 
-  private Underholdskostnadberegning underholdskostnadberegning;
+  private UnderholdskostnadBeregning underholdskostnadberegning;
 
   public BeregnUnderholdskostnadResultat beregnPerioder(
       BeregnUnderholdskostnadGrunnlag beregnUnderholdskostnadGrunnlag) {

--- a/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/bo/corebo.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/bo/corebo.kt
@@ -1,0 +1,39 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo
+
+import no.nav.bidrag.beregn.felles.bo.Periode
+import no.nav.bidrag.beregn.felles.bo.Sjablon
+import no.nav.bidrag.beregn.felles.bo.SjablonPeriode
+import java.time.LocalDate
+
+// Grunnlag periode
+data class BeregnBPsAndelUnderholdskostnadGrunnlag(
+    val beregnDatoFra: LocalDate,
+    val beregnDatoTil: LocalDate,
+    val inntekterPeriodeListe: List<InntekterPeriode>,
+    val sjablonPeriodeListe: List<SjablonPeriode>
+)
+
+// Resultatperiode
+data class BeregnBPsAndelUnderholdskostnadResultat(
+    val resultatPeriodeListe: List<ResultatPeriode>
+)
+
+data class ResultatPeriode(
+    val resultatDatoFraTil: Periode,
+    val resultatBeregning: ResultatBeregning,
+    val resultatGrunnlag: BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert
+)
+
+data class ResultatBeregning(
+    val resultatAndelProsent: Double
+)
+
+// Grunnlag beregning
+data class BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(
+    val inntekter: Inntekter,
+    val sjablonListe: List<Sjablon>)
+
+data class Inntekter(
+    val inntektBP: Double,
+    val inntektBM: Double,
+    val inntektBB: Double)

--- a/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/bo/periode.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/bo/periode.kt
@@ -1,0 +1,19 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo
+
+import no.nav.bidrag.beregn.felles.bo.Periode
+import no.nav.bidrag.beregn.felles.bo.PeriodisertGrunnlag
+
+data class InntekterPeriode(
+    val inntekterDatoFraTil: Periode,
+    val inntektBP: Double,
+    val inntektBM: Double,
+    val inntektBB: Double) : PeriodisertGrunnlag {
+  constructor(inntekterPeriode: InntekterPeriode)
+      : this(inntekterPeriode.inntekterDatoFraTil.justerDatoer(),
+      inntekterPeriode.inntektBP,
+      inntekterPeriode.inntektBM,
+      inntekterPeriode.inntektBB)
+  override fun getDatoFraTil(): Periode {
+    return inntekterDatoFraTil
+  }
+}

--- a/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/dto/coredto.kt
+++ b/src/main/kotlin/no/nav/bidrag/beregn/bpsandelunderholdskostnad/dto/coredto.kt
@@ -1,0 +1,46 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto
+
+import no.nav.bidrag.beregn.felles.dto.AvvikCore
+import no.nav.bidrag.beregn.felles.dto.PeriodeCore
+import no.nav.bidrag.beregn.felles.dto.SjablonCore
+import no.nav.bidrag.beregn.felles.dto.SjablonPeriodeCore
+import java.time.LocalDate
+
+// Grunnlag periode
+data class BeregnBPsAndelUnderholdskostnadGrunnlagCore(
+    val beregnDatoFra: LocalDate,
+    val beregnDatoTil: LocalDate,
+    val inntekterPeriodeListe: List<InntekterPeriodeCore>,
+    var sjablonPeriodeListe: List<SjablonPeriodeCore>
+)
+
+data class InntekterPeriodeCore(
+    val inntekterPeriodeDatoFraTil: PeriodeCore,
+    val inntektBP: Double,
+    val inntektBM: Double,
+    val inntektBB: Double
+)
+
+
+// Resultat
+data class BeregnBPsAndelUnderholdskostnadResultatCore(
+    val resultatPeriodeListe: List<ResultatPeriodeCore>,
+    val avvikListe: List<AvvikCore>
+)
+
+data class ResultatPeriodeCore(
+    val resultatDatoFraTil: PeriodeCore,
+    val resultatBeregning: ResultatBeregningCore,
+    val resultatGrunnlag: ResultatGrunnlagCore
+)
+
+data class ResultatBeregningCore(
+    val resultatAndelProsent: Double
+)
+
+data class ResultatGrunnlagCore(
+    val inntektBP: Double,
+    val inntektBM: Double,
+    val inntektBB: Double,
+    val sjablonListe: List<SjablonCore>
+)

--- a/src/test/java/no/nav/bidrag/beregn/TestUtil.java
+++ b/src/test/java/no/nav/bidrag/beregn/TestUtil.java
@@ -278,6 +278,11 @@ public class TestUtil {
         Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 3487d))));
     sjablonListe.add(new Sjablon(SjablonTallNavn.SKATT_ALMINNELIG_INNTEKT_PROSENT.getNavn(), emptyList(),
         Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 25.05d))));
+    sjablonListe.add(new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+        Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 1640d))));
+
+
+
 
 
     // Trinnvis skattesats

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningGrunnlagTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningGrunnlagTest.java
@@ -1,0 +1,29 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import no.nav.bidrag.beregn.TestUtil;
+import no.nav.bidrag.beregn.felles.SjablonUtil;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+import no.nav.bidrag.beregn.felles.enums.SjablonNavn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Test hent av sjablonverdier for trinnvis skattesats")
+public class BPsAndelUnderholdskostnadBeregningGrunnlagTest {
+
+  private List<Sjablon> sjablonListe = TestUtil.byggSjabloner();
+
+  @Test
+  void hentSjablon() {
+
+    var sortertTrinnvisSkattesatsListe = SjablonUtil
+        .hentTrinnvisSkattesats(sjablonListe, SjablonNavn.TRINNVIS_SKATTESATS);
+
+    assertThat(sortertTrinnvisSkattesatsListe.size()).isEqualTo(4);
+    assertThat(sortertTrinnvisSkattesatsListe.get(0).getInntektGrense()).isEqualTo(174500d);
+    assertThat(sortertTrinnvisSkattesatsListe.get(0).getSats()).isEqualTo(1.9d);
+
+  }
+}

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
@@ -1,0 +1,47 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+import no.nav.bidrag.beregn.TestUtil;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.beregning.BPsAndelUnderholdskostnadBeregningImpl;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.Inntekter;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatBeregning;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Test av beregning av BPs andel av underholdskostnad")
+public class BPsAndelUnderholdskostnadBeregningTest {
+
+    private Double inntektBP = 0.0;
+    private Double inntektBM = 0.0;
+    private Double inntektBB = 0.0;
+    private List<Sjablon> sjablonListe = TestUtil.byggSjabloner();
+
+    @DisplayName("Beregning med inntekter for alle parter")
+    @Test
+    void testBeregningMedInntekterForAlle() {
+      var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+      inntektBP = Double.valueOf(217666);
+      inntektBM = Double.valueOf(400000);
+      inntektBB = Double.valueOf(400000);
+
+      Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+      var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+          new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+      ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregn(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+      assertAll(
+          () -> assertThat(resultat).isNotNull(),
+          () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(0.214)
+      );
+    }
+
+}

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
@@ -29,7 +29,7 @@ public class BPsAndelUnderholdskostnadBeregningTest {
 
       inntektBP = Double.valueOf(217666);
       inntektBM = Double.valueOf(400000);
-      inntektBB = Double.valueOf(400000);
+      inntektBB = Double.valueOf(40000);
 
       Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
 
@@ -40,8 +40,143 @@ public class BPsAndelUnderholdskostnadBeregningTest {
 
       assertAll(
           () -> assertThat(resultat).isNotNull(),
-          () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(0.214)
+          () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(33.1)
       );
     }
 
+  @DisplayName("Beregning der barnets inntekter er høyere enn 100 * forhøyet forskuddssats. Andel skal da bli 0")
+  @Test
+  void testAndelLikNullVedHoyInntektBarn() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(217666);
+    inntektBM = Double.valueOf(400000);
+    inntektBB = Double.valueOf(400000);
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregn(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(0.0)
+    );
+  }
+
+
+  @DisplayName("Test at beregnet andel ikke settes høyere enn 5/6 (83,3)")
+  @Test
+  void testAtMaksAndelSettes() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(1000000);
+    inntektBM = Double.valueOf(40000);
+    inntektBB = Double.valueOf(40000);
+
+    // Beregnet andel skal da bli 92,6%, overstyres til 5/6 (83,3%)
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregn(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(83.3)
+    );
+  }
+
+
+  @DisplayName("Beregning med 0 i inntekt for barn")
+  @Test
+  void testBeregningMedNullInntektBarn() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(502000);
+    inntektBM = Double.valueOf(500000);
+    inntektBB = Double.valueOf(0);
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregn(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(50.1)
+    );
+  }
+
+  @DisplayName("Beregning med gamle regler, beregnet andel skal avrundes til nærmeste sjettedel (maks 5/6)")
+  @Test
+  void testBeregningGamleReglerAvrundTreSjettedeler() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(502000);
+    inntektBM = Double.valueOf(500000);
+    inntektBB = Double.valueOf(0);
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregnMedGamleRegler(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(50.0)
+    );
+  }
+
+  @DisplayName("Beregning med gamle regler, andel skal rundes opp til 1/6")
+  @Test
+  void testBeregningGamleReglerAvrundEnSjettedel() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(2000);
+    inntektBM = Double.valueOf(500000);
+    inntektBB = Double.valueOf(1000);
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregnMedGamleRegler(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(16.7)
+    );
+  }
+
+  @DisplayName("Beregning med gamle regler, andel skal rundes ned til maks andel, 5/6")
+  @Test
+  void testBeregningGamleReglerAvrundFemSjettedeler() {
+    var bPsAndelUnderholdskostnadBeregning = new BPsAndelUnderholdskostnadBeregningImpl();
+
+    inntektBP = Double.valueOf(2000000);
+    inntektBM = Double.valueOf(2000);
+    inntektBB = Double.valueOf(1000);
+
+    Inntekter inntekter = new Inntekter(inntektBP, inntektBM, inntektBB);
+
+    var beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert =
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(inntekter, sjablonListe);
+
+    ResultatBeregning resultat = bPsAndelUnderholdskostnadBeregning.beregnMedGamleRegler(beregnBPsAndelUnderholdskostnadGrunnlagPeriodisert);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(83.3)
+    );
+  }
 }

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadBeregningTest.java
@@ -179,4 +179,6 @@ public class BPsAndelUnderholdskostnadBeregningTest {
         () -> assertThat(resultat.getResultatAndelProsent()).isEqualTo(83.3)
     );
   }
+
+
 }

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCoreTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadCoreTest.java
@@ -1,0 +1,173 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadResultat;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.Inntekter;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatBeregning;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.ResultatPeriode;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.BeregnBPsAndelUnderholdskostnadGrunnlagCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.dto.InntekterPeriodeCore;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode.BPsAndelUnderholdskostnadPeriode;
+import no.nav.bidrag.beregn.felles.bo.Avvik;
+import no.nav.bidrag.beregn.felles.bo.Periode;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+import no.nav.bidrag.beregn.felles.bo.SjablonInnhold;
+import no.nav.bidrag.beregn.felles.dto.PeriodeCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonInnholdCore;
+import no.nav.bidrag.beregn.felles.dto.SjablonPeriodeCore;
+import no.nav.bidrag.beregn.felles.enums.AvvikType;
+import no.nav.bidrag.beregn.felles.enums.SjablonInnholdNavn;
+import no.nav.bidrag.beregn.felles.enums.SjablonTallNavn;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisplayName("BPsAndelUnderholdskostnadCore (dto-test)")
+public class BPsAndelUnderholdskostnadCoreTest {
+
+  private BPsAndelUnderholdskostnadCore bPsAndelunderholdskostnadCore;
+
+  private List<Sjablon> sjablonListe = new ArrayList<>();
+
+  @Mock
+  private BPsAndelUnderholdskostnadPeriode bPsAndelunderholdskostnadPeriodeMock;
+
+  private BeregnBPsAndelUnderholdskostnadGrunnlagCore beregnBPsAndelUnderholdskostnadGrunnlagCore;
+  private BeregnBPsAndelUnderholdskostnadResultat bPsAndelunderholdskostnadPeriodeResultat;
+  private List<Avvik> avvikListe;
+
+  @BeforeEach
+  void initMocksAndService() {
+    MockitoAnnotations.initMocks(this);
+    bPsAndelunderholdskostnadCore = new BPsAndelUnderholdskostnadCoreImpl(
+        bPsAndelunderholdskostnadPeriodeMock);
+  }
+
+  @Test
+  @DisplayName("Skal beregne BPsAndel av underholdskostnad")
+  void skalBeregneBPsAndelunderholdskostnad() {
+    byggBPsAndelUnderholdskostnadPeriodeGrunnlagCore();
+    byggBPsAndelUnderholdskostnadPeriodeResultat();
+
+    when(bPsAndelunderholdskostnadPeriodeMock.beregnPerioder(any())).thenReturn(
+        bPsAndelunderholdskostnadPeriodeResultat);
+    var beregnBPsAndelUnderholdskostnadResultatCore = bPsAndelunderholdskostnadCore.beregnBPsAndelUnderholdskostnad(
+        beregnBPsAndelUnderholdskostnadGrunnlagCore);
+
+    assertAll(
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore).isNotNull(),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getAvvikListe()).isEmpty(),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe()).isNotEmpty(),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().size()).isEqualTo(3),
+
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getPeriodeDatoFra())
+            .isEqualTo(LocalDate.parse("2017-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getPeriodeDatoTil())
+            .isEqualTo(LocalDate.parse("2018-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent())
+            .isEqualTo(Double.valueOf(666)),
+
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getPeriodeDatoFra())
+            .isEqualTo(LocalDate.parse("2018-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getPeriodeDatoTil())
+            .isEqualTo(LocalDate.parse("2019-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(1).getResultatBeregning().getResultatAndelProsent())
+            .isEqualTo(Double.valueOf(667)),
+
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getPeriodeDatoFra())
+            .isEqualTo(LocalDate.parse("2019-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getPeriodeDatoTil())
+            .isEqualTo(LocalDate.parse("2020-01-01")),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(2).getResultatBeregning().getResultatAndelProsent())
+            .isEqualTo(Double.valueOf(668)),
+        () -> assertThat(beregnBPsAndelUnderholdskostnadResultatCore.getResultatPeriodeListe().get(0).getResultatGrunnlag().getSjablonListe().get(0)
+            .getSjablonInnholdListe().get(0).getSjablonInnholdVerdi()).isEqualTo(1600)
+
+    );
+  }
+
+  @Test
+  @DisplayName("Skal ikke beregne BPs andel av underholdskostnad ved avvik")
+  void skalIkkeBeregneAndelVedAvvik() {
+    byggBPsAndelUnderholdskostnadPeriodeGrunnlagCore();
+    byggAvvik();
+
+    when(bPsAndelunderholdskostnadPeriodeMock.validerInput(any())).thenReturn(avvikListe);
+    var beregnbidragsevneResultatCore = bPsAndelunderholdskostnadCore.beregnBPsAndelUnderholdskostnad(
+        beregnBPsAndelUnderholdskostnadGrunnlagCore);
+
+    assertAll(
+        () -> assertThat(beregnbidragsevneResultatCore).isNotNull(),
+        () -> assertThat(beregnbidragsevneResultatCore.getAvvikListe()).isNotEmpty(),
+        () -> assertThat(beregnbidragsevneResultatCore.getAvvikListe()).hasSize(1),
+        () -> assertThat(beregnbidragsevneResultatCore.getAvvikListe().get(0).getAvvikTekst()).isEqualTo("beregnDatoTil må være etter beregnDatoFra"),
+        () -> assertThat(beregnbidragsevneResultatCore.getAvvikListe().get(0).getAvvikType()).isEqualTo(
+            AvvikType.DATO_FRA_ETTER_DATO_TIL.toString()),
+        () -> assertThat(beregnbidragsevneResultatCore.getResultatPeriodeListe()).isEmpty()
+    );
+  }
+
+
+  private void byggBPsAndelUnderholdskostnadPeriodeGrunnlagCore() {
+
+    var inntekterPeriode = new InntekterPeriodeCore(
+        new PeriodeCore(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01")), 111, 222, 333);
+    var inntekterPeriodeListe = new ArrayList<InntekterPeriodeCore>();
+    inntekterPeriodeListe.add(inntekterPeriode);
+
+    var sjablonPeriode = new SjablonPeriodeCore(new PeriodeCore(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01")),
+        SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+        Arrays.asList(new SjablonInnholdCore(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 1600d)));
+    var sjablonPeriodeListe = new ArrayList<SjablonPeriodeCore>();
+    sjablonPeriodeListe.add(sjablonPeriode);
+
+    beregnBPsAndelUnderholdskostnadGrunnlagCore = new BeregnBPsAndelUnderholdskostnadGrunnlagCore(LocalDate.parse("2017-01-01"), LocalDate.parse("2020-01-01"),
+        inntekterPeriodeListe, sjablonPeriodeListe);
+  }
+
+  private void byggBPsAndelUnderholdskostnadPeriodeResultat() {
+    List<ResultatPeriode> periodeResultatListe = new ArrayList<>();
+
+    periodeResultatListe.add(new ResultatPeriode(
+        new Periode(LocalDate.parse("2017-01-01"), LocalDate.parse("2018-01-01")),
+        new ResultatBeregning(Double.valueOf(666)),
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(new Inntekter(111, 222, 333),
+            Arrays.asList(new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+                Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 1600d)))))));
+
+    periodeResultatListe.add(new ResultatPeriode(
+        new Periode(LocalDate.parse("2018-01-01"), LocalDate.parse("2019-01-01")),
+        new ResultatBeregning(Double.valueOf(667)),
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(new Inntekter(111, 222, 333),
+            Arrays.asList(new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+                Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 1640d)))))));
+
+    periodeResultatListe.add(new ResultatPeriode(
+        new Periode(LocalDate.parse("2019-01-01"), LocalDate.parse("2020-01-01")),
+        new ResultatBeregning(Double.valueOf(668)),
+        new BeregnBPsAndelUnderholdskostnadGrunnlagPeriodisert(new Inntekter(111, 222, 333),
+            Arrays.asList(new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+                Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(), 1640d)))))));
+
+
+    bPsAndelunderholdskostnadPeriodeResultat = new BeregnBPsAndelUnderholdskostnadResultat(periodeResultatListe);
+  }
+
+  private void byggAvvik() {
+    avvikListe = new ArrayList<>();
+    avvikListe.add(new Avvik("beregnDatoTil må være etter beregnDatoFra", AvvikType.DATO_FRA_ETTER_DATO_TIL));
+  }
+
+}

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadPeriodeTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadPeriodeTest.java
@@ -1,0 +1,157 @@
+package no.nav.bidrag.beregn.bpsandelunderholdskostnad;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadGrunnlag;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.BeregnBPsAndelUnderholdskostnadResultat;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.bo.InntekterPeriode;
+import no.nav.bidrag.beregn.bpsandelunderholdskostnad.periode.BPsAndelUnderholdskostnadPeriode;
+import no.nav.bidrag.beregn.felles.bo.Periode;
+import no.nav.bidrag.beregn.felles.bo.Sjablon;
+import no.nav.bidrag.beregn.felles.bo.SjablonInnhold;
+import no.nav.bidrag.beregn.felles.bo.SjablonNokkel;
+import no.nav.bidrag.beregn.felles.bo.SjablonPeriode;
+import no.nav.bidrag.beregn.felles.enums.SjablonInnholdNavn;
+import no.nav.bidrag.beregn.felles.enums.SjablonNavn;
+import no.nav.bidrag.beregn.felles.enums.SjablonNokkelNavn;
+import no.nav.bidrag.beregn.felles.enums.SjablonTallNavn;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class BPsAndelUnderholdskostnadPeriodeTest {
+
+    private BPsAndelUnderholdskostnadPeriode bPsAndelunderholdskostnadPeriode = BPsAndelUnderholdskostnadPeriode.getInstance();
+
+    @DisplayName("Test av periodisering. Periodene i grunnlaget skal gjenspeiles i resultatperiodene")
+    @Test
+    void testPeriodisering() {
+      System.out.println("Starter test");
+      var beregnDatoFra = LocalDate.parse("2018-07-01");
+      var beregnDatoTil = LocalDate.parse("2020-08-01");
+
+      // Lag inntekter
+      var inntekterPeriodeListe = new ArrayList<InntekterPeriode>();
+      inntekterPeriodeListe.add(new InntekterPeriode(
+          new Periode(LocalDate.parse("2018-01-01"), LocalDate.parse("2020-08-01")),
+          217666, 400000, 40000));
+
+      // Lag sjabloner
+      var sjablonPeriodeListe = new ArrayList<SjablonPeriode>();
+      sjablonPeriodeListe.add(new SjablonPeriode(
+          new Periode(LocalDate.parse("2018-07-01"), LocalDate.parse("2019-06-30")),
+          new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+              Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(),
+                  1600d)))));
+      sjablonPeriodeListe.add(new SjablonPeriode(
+          new Periode(LocalDate.parse("2019-07-01"), LocalDate.parse("2020-06-30")),
+          new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+              Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(),
+                  1640d)))));
+      sjablonPeriodeListe.add(new SjablonPeriode(
+          new Periode(LocalDate.parse("2020-07-01"), null),
+          new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+              Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(),
+                  1670d)))));
+
+      BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag =
+          new BeregnBPsAndelUnderholdskostnadGrunnlag(beregnDatoFra, beregnDatoTil, inntekterPeriodeListe,
+              sjablonPeriodeListe);
+
+      var resultat = bPsAndelunderholdskostnadPeriode.beregnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag);
+
+      assertAll(
+          () -> assertThat(resultat).isNotNull(),
+          () -> assertThat(resultat.getResultatPeriodeListe()).isNotEmpty(),
+          () -> assertThat(resultat.getResultatPeriodeListe().size()).isEqualTo(3),
+
+          () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2018-07-01")),
+          () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2019-07-01")),
+          () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(33.1d),
+
+          () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2019-07-01")),
+          () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2020-07-01")),
+
+          () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2020-07-01")),
+          () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoTil()).isNull()
+      );
+
+      printGrunnlagResultat(resultat);
+    }
+
+  @DisplayName("Test av beregning med gamle og nye regler. Resultat for perioder før 2009 skal angis i nærmeste sjettedel."
+      + "Det skal også lages brudd i periode ved overgang til nye regler 01.01.2009")
+  @Test
+  void testBeregningMedGamleOgNyeRegler() {
+    System.out.println("Starter test");
+    var beregnDatoFra = LocalDate.parse("2008-01-01");
+    var beregnDatoTil = LocalDate.parse("2009-07-01");
+
+    // Lag inntekter
+    var inntekterPeriodeListe = new ArrayList<InntekterPeriode>();
+    inntekterPeriodeListe.add(new InntekterPeriode(
+        new Periode(LocalDate.parse("2008-01-01"), LocalDate.parse("2020-08-01")),
+        300000, 400000, 40000));
+
+    // Lag sjabloner
+    var sjablonPeriodeListe = new ArrayList<SjablonPeriode>();
+    sjablonPeriodeListe.add(new SjablonPeriode(
+        new Periode(LocalDate.parse("2008-01-01"), LocalDate.parse("2008-06-30")),
+        new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+            Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(),
+                1600d)))));
+    sjablonPeriodeListe.add(new SjablonPeriode(
+        new Periode(LocalDate.parse("2008-07-01"), LocalDate.parse("2019-06-30")),
+        new Sjablon(SjablonTallNavn.FORSKUDDSSATS_BELOP.getNavn(), emptyList(),
+            Arrays.asList(new SjablonInnhold(SjablonInnholdNavn.SJABLON_VERDI.getNavn(),
+                1700d)))));
+
+    BeregnBPsAndelUnderholdskostnadGrunnlag beregnBPsAndelUnderholdskostnadGrunnlag =
+        new BeregnBPsAndelUnderholdskostnadGrunnlag(beregnDatoFra, beregnDatoTil, inntekterPeriodeListe,
+            sjablonPeriodeListe);
+
+    var resultat = bPsAndelunderholdskostnadPeriode.beregnPerioder(beregnBPsAndelUnderholdskostnadGrunnlag);
+
+    assertAll(
+        () -> assertThat(resultat).isNotNull(),
+        () -> assertThat(resultat.getResultatPeriodeListe()).isNotEmpty(),
+//        () -> assertThat(resultat.getResultatPeriodeListe().size()).isEqualTo(3),
+
+        // Gamle regler
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2008-01-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2008-07-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(33.3d),
+
+        // Gamle regler
+        () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2008-07-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2009-01-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(33.3d)
+        /*,
+
+        // Nye regler
+        () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2009-01-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoTil()).isNull(),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(40.5d)*/
+    );
+
+    printGrunnlagResultat(resultat);
+  }
+
+
+
+  private void printGrunnlagResultat(
+        BeregnBPsAndelUnderholdskostnadResultat beregnBPsAndelUnderholdskostnadResultat) {
+      beregnBPsAndelUnderholdskostnadResultat.getResultatPeriodeListe().stream().sorted(
+          Comparator.comparing(pR -> pR.getResultatDatoFraTil().getDatoFra()))
+          .forEach(sortedPR -> System.out
+              .println("Dato fra: " + sortedPR.getResultatDatoFraTil().getDatoFra() + "; " + "Dato til: "
+                  + sortedPR.getResultatDatoFraTil().getDatoTil()
+                  + "; " + "Prosentandel: " + sortedPR.getResultatBeregning().getResultatAndelProsent()));
+    }
+}

--- a/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadPeriodeTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/bpsandelunderholdskostnad/BPsAndelUnderholdskostnadPeriodeTest.java
@@ -96,8 +96,11 @@ public class BPsAndelUnderholdskostnadPeriodeTest {
     // Lag inntekter
     var inntekterPeriodeListe = new ArrayList<InntekterPeriode>();
     inntekterPeriodeListe.add(new InntekterPeriode(
-        new Periode(LocalDate.parse("2008-01-01"), LocalDate.parse("2020-08-01")),
+        new Periode(LocalDate.parse("2008-01-01"), LocalDate.parse("2009-06-01")),
         300000, 400000, 40000));
+    inntekterPeriodeListe.add(new InntekterPeriode(
+        new Periode(LocalDate.parse("2009-06-01"), LocalDate.parse("2020-08-01")),
+        3000, 400000, 4000000));
 
     // Lag sjabloner
     var sjablonPeriodeListe = new ArrayList<SjablonPeriode>();
@@ -121,7 +124,7 @@ public class BPsAndelUnderholdskostnadPeriodeTest {
     assertAll(
         () -> assertThat(resultat).isNotNull(),
         () -> assertThat(resultat.getResultatPeriodeListe()).isNotEmpty(),
-//        () -> assertThat(resultat.getResultatPeriodeListe().size()).isEqualTo(3),
+        () -> assertThat(resultat.getResultatPeriodeListe().size()).isEqualTo(4),
 
         // Gamle regler
         () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2008-01-01")),
@@ -131,13 +134,16 @@ public class BPsAndelUnderholdskostnadPeriodeTest {
         // Gamle regler
         () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2008-07-01")),
         () -> assertThat(resultat.getResultatPeriodeListe().get(1).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2009-01-01")),
-        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(33.3d)
-        /*,
+        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(33.3d),
 
         // Nye regler
         () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2009-01-01")),
-        () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoTil()).isNull(),
-        () -> assertThat(resultat.getResultatPeriodeListe().get(0).getResultatBeregning().getResultatAndelProsent()).isEqualTo(40.5d)*/
+        () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2009-06-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(2).getResultatBeregning().getResultatAndelProsent()).isEqualTo(40.5d),
+
+        () -> assertThat(resultat.getResultatPeriodeListe().get(3).getResultatDatoFraTil().getDatoFra()).isEqualTo(LocalDate.parse("2009-06-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(3).getResultatDatoFraTil().getDatoTil()).isEqualTo(LocalDate.parse("2009-07-01")),
+        () -> assertThat(resultat.getResultatPeriodeListe().get(3).getResultatBeregning().getResultatAndelProsent()).isEqualTo(0.0d)
     );
 
     printGrunnlagResultat(resultat);

--- a/src/test/java/no/nav/bidrag/beregn/underholdskostnad/UnderholdskostnadBeregningGrunnlagTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/underholdskostnad/UnderholdskostnadBeregningGrunnlagTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Test hent av sjablonverdier for trinnvis skattesats")
-public class UnderholdskostnadberegningGrunnlagTest {
+public class UnderholdskostnadBeregningGrunnlagTest {
 
   private List<Sjablon> sjablonListe = TestUtil.byggSjabloner();
 

--- a/src/test/java/no/nav/bidrag/beregn/underholdskostnad/UnderholdskostnadBeregningTest.java
+++ b/src/test/java/no/nav/bidrag/beregn/underholdskostnad/UnderholdskostnadBeregningTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 import no.nav.bidrag.beregn.TestUtil;
 import no.nav.bidrag.beregn.felles.bo.Sjablon;
-import no.nav.bidrag.beregn.underholdskostnad.beregning.UnderholdskostnadberegningImpl;
+import no.nav.bidrag.beregn.underholdskostnad.beregning.UnderholdskostnadBeregningImpl;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BarnetilsynMedStonad;
 import no.nav.bidrag.beregn.underholdskostnad.bo.BeregnUnderholdskostnadGrunnlagPeriodisert;
 
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("Test av beregning Underholdskostnad")
-class UnderholdskostnadberegningTest {
+class UnderholdskostnadBeregningTest {
   private List<Sjablon> sjablonListe = TestUtil.byggSjabloner();
 
   @DisplayName("Test av beregning av underholdskostnad når barnet er 3 år gammelt")
   @Test
   void testBeregningAlder3MedKunSjablonverdier() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(3,
@@ -38,7 +38,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder7MedKunSjablonverdier() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(7,
@@ -56,7 +56,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder10MedKunSjablonverdier() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(10,
@@ -74,7 +74,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder11MedKunSjablonverdier() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(11,
@@ -93,7 +93,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testStonadBarnetilsynDU() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(11,
@@ -111,7 +111,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder11StonadBarnetilsynDU() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(11,
@@ -128,7 +128,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder11MedNettoBarnetilsyn() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(11,
@@ -146,7 +146,7 @@ class UnderholdskostnadberegningTest {
   @Test
   void testBeregningAlder11MedForpleiningsutgifter() {
 
-    UnderholdskostnadberegningImpl underholdskostnadberegning = new UnderholdskostnadberegningImpl();
+    UnderholdskostnadBeregningImpl underholdskostnadberegning = new UnderholdskostnadBeregningImpl();
 
     BeregnUnderholdskostnadGrunnlagPeriodisert beregnUnderholdskostnadGrunnlagPeriodisert
         = new BeregnUnderholdskostnadGrunnlagPeriodisert(11,


### PR DESCRIPTION
Kan du ta en kikk på endringene jeg har gjort i BPsAndelUnderholdskostnadPeriodeImpl?
Jeg har lagt til:         .
addBruddpunkt(beregnBPsAndelUnderholdskostnadGrunnlag.getBeregnDatoTil()) //For å sikre bruddpunkt på start-beregning-til-dato for å få lagd minst én resultatperiode i de situasjonene der det ikke er
bruddpunkter for andre parametre.
Du kan jo se på resten av koden også hvis du har tid :-)
